### PR TITLE
Update flask dependency to X where 2 <= X < 3

### DIFF
--- a/invokers/python/setup.py
+++ b/invokers/python/setup.py
@@ -23,7 +23,7 @@ setup(
     license='Apache',
     install_requires=[
         'cloudevents >=1.2, <2',
-        'Flask>=1.1.4,<2',
+        'Flask>=2,<3',
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest==4.4.1'],


### PR DESCRIPTION
There was a recent update to MarkupSafe's minor version which broke API compatability. This affected a library `Jinja2` used by `Flask`.

Flask 1.x is no longer actively worked on, and thus the breaking change will remain unless we pin to an older version of `MarkupSafe`. We decided to update to Flask 2 instead.