### PR TITLE
Make templates usable for func create

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,13 +5,4 @@
 # in the UX, and its version
 name: function-buildpacks-for-knative
 
-# Runtimes is a list of language packs supported by this repository
-runtimes:
-  - path: buildpacks       # Required. The path of the runtime directory from the repository root
-    name: buildpacks       # Optional. Name of the runtime; if not provided, path will be used
-
-    # A list of templates supplied by this language pack
-    templates:     # Required. One or more templates that correspond to directories within this language pack
-    - path: templates # Required. The path to the template directory from the language pack root
-      name: templates  # Optional. The name of the template; if not provided path will be used
-
+templates: templates


### PR DESCRIPTION
Signed-off-by: Fabian Lopez <lfabian@vmware.com>

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Please open an issue first, if none exists.
-->
Partially fixes: #30

## What this PR solves
Makes templates usable by `kn func create`
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->

## Details for release notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Create via kn-func can now make use the java and python templates from this repo:
kn func create -r https://github.com/vmware-tanzu/function-buildpacks-for-knative.git -l java -t (cloudevents-maven|cloudevents-gradle|http-maven|http-gradle)
kn func create -r https://github.com/vmware-tanzu/function-buildpacks-for-knative.git -l python -t (cloudevents|http)
```

## Describe testing done for PR
Created a fork for this repo and by making the same changes in this PR to the `manifest.yaml` I was able to create functions by pointing to my fork with the `-r` flag
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
As mentioned in the linked issue, there still is the problem of building the generated functions with our buildpacks
<!--
Add any things that reviewers should be aware of as they review
your PR. You can also @mention a reviewer here, if needed.

Example: Please verify how I handled foo aligns with overall plan.
-->
