### PR TITLE
Use python waitress server instead of the flask built-in

### DIFF
--- a/invokers/python/pyfunc/__main__.py
+++ b/invokers/python/pyfunc/__main__.py
@@ -18,7 +18,7 @@ def start(args):
     invoke.main(args.search_path)
 
 parser = ArgumentParser(prog='pyfunc')
-parser.set_defaults(func=lambda args: parser.print_help())
+parser.set_defaults(func=lambda: parser.print_help())
 subparsers = parser.add_subparsers(help='sub-command help')
 
 parser_check = subparsers.add_parser('check', help='check if the module and function can be loaded')

--- a/invokers/python/setup.py
+++ b/invokers/python/setup.py
@@ -26,7 +26,8 @@ setup(
     license='Apache',
     install_requires=[
         'cloudevents >=1.2, <2',
-        'Flask>=2,<3',
+        'Flask >=2,<3',
+        'waitress >=2',
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest==4.4.1'],


### PR DESCRIPTION
## Which issue(s) this PR fixes
#53 

## What this PR solves
This replaces the usage of the built-in flask webserver with waitress.

## Details for release notes
```release-note
* Added new dependency on waitress
* Replaced built-in flask webserver with waitress
```

## Describe testing done for PR
Ran it locally.

## Notes
The [license](https://github.com/Pylons/waitress/blob/master/LICENSE.txt) for waitress is Zope Public License (ZPL) 2.1.
According to [wikipedia](https://en.wikipedia.org/wiki/Zope_Public_License), this is OSI and FSF approved.
[TLDRLegal](https://tldrlegal.com/license/zope-public-license-2.1-(zpl-2.1)) looks pretty permissive as well.
I am not a lawyer.