### PR TITLE
Add python invoker dependency as buildpack dependency (offline usecase)

### DIFF
--- a/buildpacks/python/buildpack.toml
+++ b/buildpacks/python/buildpack.toml
@@ -16,7 +16,14 @@ api = "0.6"
   [[metadata.dependencies]]
     id      = "invoker"
     name    = "Python Invoker"
-    version = "0.0.3"
-    uri     = "https://github.com/vmware-tanzu/function-buildpacks-for-knative/releases/download/python-invoker%2Fv0.0.4/pyfunc-invoker-0.0.4.tar.gz"
-    sha256  = "427a0eacdbfde110fe4d85a32741dc47e4003b7f8b04c7fa2cf34873e66c8b51"
+    version = "0.0.5"
+    uri     = "https://github.com/vmware-tanzu/function-buildpacks-for-knative/releases/download/python-invoker%2Fv0.0.5/pyfunc-invoker-0.0.5.tar.gz"
+    sha256  = "b43a45cc6c3c2420b2331b627f97b133ea9312731791e5a76a5cd72ff3cb5811"
+    stacks  = [ "io.buildpacks.stacks.bionic" ]
+  [[metadata.dependencies]]
+    id      = "invoker-deps"
+    name    = "Python Invoker Deps"
+    version = "0.0.5"
+    uri     = "https://github.com/vmware-tanzu/function-buildpacks-for-knative/releases/download/python-invoker%2Fv0.0.5/pyfunc-invoker-deps-0.0.5.tar.gz"
+    sha256  = "a84056dbdd4d570ab2aa6e05a04f96ee5a54be18ee1141282133fb13bb634e0f"
     stacks  = [ "io.buildpacks.stacks.bionic" ]

--- a/buildpacks/python/go.sum
+++ b/buildpacks/python/go.sum
@@ -1223,6 +1223,7 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b/go.mod h1:N2
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/buildpacks/python/python/invoker_dependency_cache.go
+++ b/buildpacks/python/python/invoker_dependency_cache.go
@@ -1,0 +1,47 @@
+// Copyright 2021-2022 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+package python
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/crush"
+)
+
+type InvokerDependencyCache struct {
+	LayerContributor libpak.DependencyLayerContributor
+	Logger           bard.Logger
+
+	CacheDir string
+}
+
+func NewInvokerDependencyCache(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) (InvokerDependencyCache, libcnb.BOMEntry) {
+	contributor, entry := libpak.NewDependencyLayer(dependency, cache, libcnb.LayerTypes{
+		Launch: true,
+	})
+	return InvokerDependencyCache{LayerContributor: contributor}, entry
+}
+
+func (i InvokerDependencyCache) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
+	i.LayerContributor.Logger = i.Logger
+	i.CacheDir = layer.Path
+
+	return i.LayerContributor.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+		i.Logger.Bodyf("Installing to %s", artifact.Name())
+
+		if err := crush.ExtractTarGz(artifact, layer.Path, 0); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to extract %s\n%w", artifact.Name(), err)
+		}
+
+		return layer, nil
+	})
+}
+
+func (i InvokerDependencyCache) Name() string {
+	return i.LayerContributor.Name()
+}


### PR DESCRIPTION
## Which issue(s) this PR fixes
Part of: #56 

## What this PR solves
This adds the cached dependencies for running the invoker.

## Details for release notes
```release-note
Invoker dependencies are now fetched and cached onto the image so it doesn't need to be pulled during install time.
```
