### PR TITLE
Update examples to use latest builder

### DIFF
--- a/samples/java/cloudevents/txt-to-pdf-maven/Makefile
+++ b/samples/java/cloudevents/txt-to-pdf-maven/Makefile
@@ -5,7 +5,7 @@ FUNCTION_IMAGE ?= us.gcr.io/daisy-284300/functions/demo:txttopdfjava
 FUNCTION := out/image
 $(FUNCTION):
 	@mkdir -p $(@D)
-	pack build $(FUNCTION_IMAGE) --path ./spring-java-fn/ --builder us.gcr.io/daisy-284300/kn-fn/builder:latest
+	pack build $(FUNCTION_IMAGE) --path ./spring-java-fn/ --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
 	printf $(FUNCTION_IMAGE) > $@
 
 build: $(FUNCTION)

--- a/samples/python/cloudevents/s3_lamba/README.md
+++ b/samples/python/cloudevents/s3_lamba/README.md
@@ -1,6 +1,6 @@
 To deploy this, first create the container with the buildpack cli
 ```
-pack build <your_image_name_and_tag> --builder us.gcr.io/daisy-284300/kn-fn/builder:0.0.6
+pack build <your_image_name_and_tag> --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
 ```
 
 Publish it to your registry:

--- a/samples/python/cloudevents/sqs-lambda/README.md
+++ b/samples/python/cloudevents/sqs-lambda/README.md
@@ -64,7 +64,7 @@ The folder `knative-function-encrypter` has the function that will be listening 
 With docker running, build the image from this folder:
 
 ```
-pack build encrypter --path PATH/TO/knative-function-encrypter --builder us.gcr.io/daisy-284300/kn-fn/builder:3
+pack build encrypter --path PATH/TO/knative-function-encrypter --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
 ```
 
 Tag and push to your registry:

--- a/samples/python/cloudevents/txt-to-pdf/Makefile
+++ b/samples/python/cloudevents/txt-to-pdf/Makefile
@@ -5,7 +5,7 @@ FUNCTION_IMAGE ?= us.gcr.io/daisy-284300/functions/demo:txttopdf
 FUNCTION := out/image
 $(FUNCTION): app/*
 	@mkdir -p $(@D)
-	pack build $(FUNCTION_IMAGE) --path ./app/ --builder us.gcr.io/daisy-284300/kn-fn/builder:0.0.6
+	pack build $(FUNCTION_IMAGE) --path ./app/ --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
 	printf $(FUNCTION_IMAGE) > $@
 
 build: $(FUNCTION)

--- a/samples/python/http/adder/README.md
+++ b/samples/python/http/adder/README.md
@@ -5,7 +5,7 @@ This example will take two number and add them up only if the requestor is authe
 # Running the sample
 1. We want to first build the image:
     ```
-    pack build adder --builder us.gcr.io/daisy-284300/kn-fn/builder:<VERSION>
+    pack build adder --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
     ```
     * `VERSION` is the version of the builder to use.
 

--- a/templates/java/manifest.yaml
+++ b/templates/java/manifest.yaml
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 builders:
-  default: us.gcr.io/daisy-284300/kn-fn/builder:0.0.6
+  default: ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
+

--- a/templates/python/manifest.yaml
+++ b/templates/python/manifest.yaml
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 builders:
-  default: us.gcr.io/daisy-284300/kn-fn/builder:0.0.6
+  default: ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10
+


### PR DESCRIPTION
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Please open an issue first, if none exists.
-->
Fixes a potential bug with `kn func` CLI failing to build our functions (it currently pulls us.gcr.io/daisy-284300/kn-fn/builder:0.0.6)

## What this PR solves
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Potentially solves a bug; at worst, updates the builder to be our latest one and properly targeting GHCR instead.

## Details for release notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Update samples / templates to use builder@v0.0.10
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
n/a

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR. You can also @mention a reviewer here, if needed.

Example: Please verify how I handled foo aligns with overall plan.
-->
n/a
