### PR TITLE
fix: ytt cannot have headers as comments

### DIFF
--- a/samples/java/cloudevents/txt-to-pdf-maven/config/100-namespace.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/100-namespace.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: v1

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/200-broker.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/200-broker.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: eventing.knative.dev/v1

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/200-secret.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/200-secret.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 ---

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/200-source.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/200-source.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: sources.triggermesh.io/v1alpha1

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/200-trigger.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/200-trigger.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: eventing.knative.dev/v1

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/300-app-secret.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/300-app-secret.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 ---

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/function.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/function.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: serving.knative.dev/v1

--- a/samples/java/cloudevents/txt-to-pdf-maven/config/values.yaml
+++ b/samples/java/cloudevents/txt-to-pdf-maven/config/values.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@data/values
 ---
 namespace: demo

--- a/samples/python/cloudevents/txt-to-pdf/config/100-namespace.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/100-namespace.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: v1

--- a/samples/python/cloudevents/txt-to-pdf/config/200-broker.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/200-broker.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: eventing.knative.dev/v1

--- a/samples/python/cloudevents/txt-to-pdf/config/200-secret.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/200-secret.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 ---

--- a/samples/python/cloudevents/txt-to-pdf/config/200-source.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/200-source.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: sources.triggermesh.io/v1alpha1

--- a/samples/python/cloudevents/txt-to-pdf/config/200-trigger.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/200-trigger.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: eventing.knative.dev/v1

--- a/samples/python/cloudevents/txt-to-pdf/config/300-app-secret.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/300-app-secret.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 ---

--- a/samples/python/cloudevents/txt-to-pdf/config/function.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/function.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@ load("@ytt:data", "data")
 ---
 apiVersion: serving.knative.dev/v1

--- a/samples/python/cloudevents/txt-to-pdf/config/values.yaml
+++ b/samples/python/cloudevents/txt-to-pdf/config/values.yaml
@@ -1,6 +1,3 @@
-# Copyright 2021-2022 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 #@data/values
 ---
 namespace: demo


### PR DESCRIPTION
The automated copyright headers commit broke ytt functionality.