### PR TITLE
feat: delete the use of BP_DEFAULT_FUNCTION

### DIFF
--- a/buildpacks/java/README.md
+++ b/buildpacks/java/README.md
@@ -18,7 +18,6 @@ The buildpack will do the following if detection passed:
 | Environment Variable | Description |
 |----------------------|-------------|
 | `$BP_FUNCTION` | Configure the function to load. If the function lives in the default package: `<class>`. If the function lives in their own package: `<package>.<class>`. Defaults to `functions.Handler` |
-| `$BP_DEFAULT_FUNCTION` | Configure the default function. By specifying this property, a function with the name can be accessed via the `/` path. Defaults to empty. |
 
 ## Getting started
 To get started you'll need to create a directory where your function will be defined.

--- a/buildpacks/java/java/build.go
+++ b/buildpacks/java/java/build.go
@@ -49,12 +49,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	functionClass, isFuncDefDefault := cr.Resolve("BP_FUNCTION")
-	defaultDef, isDefaultFuncDefault := cr.Resolve("BP_DEFAULT_FUNCTION")
 
 	functionLayer := NewFunction(context.Application.Path,
 		WithLogger(b.Logger),
 		WithFunctionClass(functionClass, isFuncDefDefault),
-		WithDefaultFunction(defaultDef, isDefaultFuncDefault),
 		WithFuncYamlEnvs(e.Metadata["func_yaml_envs"].(map[string]interface{})),
 	)
 	result.Layers = append(result.Layers, functionLayer)

--- a/buildpacks/java/java/detect.go
+++ b/buildpacks/java/java/detect.go
@@ -20,10 +20,6 @@ func (d Detect) checkConfigs(cr libpak.ConfigurationResolver) bool {
 		return true
 	}
 
-	if _, defined := cr.Resolve("BP_DEFAULT_FUNCTION"); defined {
-		return true
-	}
-
 	return false
 }
 

--- a/buildpacks/java/java/function.go
+++ b/buildpacks/java/java/function.go
@@ -59,14 +59,6 @@ func (f Function) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			layer.LaunchEnvironment.Default("SPRING_CLOUD_FUNCTION_FUNCTION_CLASS", f.functionClass)
 		}
 
-		if len(f.defaultFunctionName) > 0 {
-			if f.overrideDefaultFunctionName {
-				layer.LaunchEnvironment.Override("SPRING_CLOUD_FUNCTION_DEFINITION", f.defaultFunctionName)
-			} else {
-				layer.LaunchEnvironment.Default("SPRING_CLOUD_FUNCTION_DEFINITION", f.defaultFunctionName)
-			}
-		}
-
 		for envName, envValue := range f.funcYamlEnvs {
 			layer.LaunchEnvironment.Default(envName, envValue)
 		}
@@ -85,16 +77,6 @@ type FunctionOpt func(fun *Function, metadata map[string]string)
 func WithLogger(logger bard.Logger) FunctionOpt {
 	return func(fun *Function, metadata map[string]string) {
 		fun.logger = logger
-	}
-}
-
-func WithDefaultFunction(defaultFunctionName string, override bool) FunctionOpt {
-	return func(fun *Function, metadata map[string]string) {
-		fun.defaultFunctionName = defaultFunctionName
-		fun.overrideDefaultFunctionName = override
-
-		metadata["bp-default-function"] = defaultFunctionName
-		metadata["bp-default-function-override"] = strconv.FormatBool(override)
 	}
 }
 

--- a/buildpacks/java/ytt/buildpack.yaml
+++ b/buildpacks/java/ytt/buildpack.yaml
@@ -25,8 +25,4 @@ metadata:
     default: functions.Handler
     description: The function to run. It must be in the format of <package>.<class>, if it is in the default package then just <class>
     name: BP_FUNCTION
-  - build: true
-    default: ""
-    description: "The default function name. In the event there are multiple functions. Specifying the name of the function will make it accessible through the root path '/'"
-    name: "BP_DEFAULT_FUNCTION"
   dependencies: []

--- a/samples/java/cloudevents/txt-to-pdf-maven/Makefile
+++ b/samples/java/cloudevents/txt-to-pdf-maven/Makefile
@@ -5,7 +5,7 @@ FUNCTION_IMAGE ?= us.gcr.io/daisy-284300/functions/demo:txttopdfjava
 FUNCTION := out/image
 $(FUNCTION):
 	@mkdir -p $(@D)
-	pack build $(FUNCTION_IMAGE) --path ./spring-java-fn/ --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10 --env BP_FUNCTION=com.example.demo.DemoApplication --env BP_DEFAULT_FUNCTION=func
+	pack build $(FUNCTION_IMAGE) --path ./spring-java-fn/ --builder ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.0.10 --env BP_FUNCTION=com.example.demo.DemoApplication
 	printf $(FUNCTION_IMAGE) > $@
 
 build: $(FUNCTION)


### PR DESCRIPTION
We are going to support Functions in the way of 

```java
package com.organization.functions

class MyFunction implements Function<T,F> {
	@Override
    public F apply(T obj) {
		.... // Code here
	}
}
```
so the attribute `BP_DEFAULT_FUNCTION` is not going to be used if defined.

To point to the function the user will specify `BP_FUNCTION=packageName.ClassName`. 

For Example,

```bash
pack .... --env BP_FUNCTION=com.organization.functions.MyFunction
```