### PR TITLE
Bump buildpack API version and change stack to wildcard

### DIFF
--- a/builder/ytt/builder.yaml
+++ b/builder/ytt/builder.yaml
@@ -5,7 +5,7 @@
 buildpacks: []
 order: []
 lifecycle:
-  uri: https://github.com/buildpacks/lifecycle/releases/download/v0.11.4/lifecycle-v0.11.4+linux.x86-64.tgz
+  uri: https://github.com/buildpacks/lifecycle/releases/download/v0.14.1/lifecycle-v0.14.1+linux.x86-64.tgz
 stack:
   id: io.buildpacks.stacks.bionic
   build-image: gcr.io/paketo-buildpacks/build:0.0.97-base-cnb

--- a/buildpacks/java/ytt/buildpack.yaml
+++ b/buildpacks/java/ytt/buildpack.yaml
@@ -3,7 +3,7 @@
 
 #@ load("@ytt:data", "data")
 ---
-api: "0.6"
+api: "0.7"
 buildpack:
   id: kn-fn/java-function
   name: Java Function Buildpack
@@ -11,7 +11,7 @@ buildpack:
   sbom-formats:
   - application/vnd.syft+json
 stacks:
-- id: io.buildpacks.stacks.bionic
+- id: "*"
 metadata:
   include-files:
   - README.md

--- a/buildpacks/java/ytt/dependencies.yaml
+++ b/buildpacks/java/ytt/dependencies.yaml
@@ -14,4 +14,4 @@ metadata:
     uri: #@ data.values.invoker.url
     sha256: #@ data.values.invoker.sha
     stacks:
-    - io.buildpacks.stacks.bionic
+    - "*"

--- a/buildpacks/python/ytt/buildpack.yaml
+++ b/buildpacks/python/ytt/buildpack.yaml
@@ -3,7 +3,7 @@
 
 #@ load("@ytt:data", "data")
 ---
-api: "0.6"
+api: "0.7"
 buildpack:
   id: kn-fn/python-function
   name: Python Function Buildpack
@@ -11,7 +11,7 @@ buildpack:
   sbom-formats:
   - application/vnd.syft+json
 stacks:
-- id: io.buildpacks.stacks.bionic
+- id: "*"
 metadata:
   include-files:
   - README.md

--- a/buildpacks/python/ytt/dependencies.yaml
+++ b/buildpacks/python/ytt/dependencies.yaml
@@ -14,11 +14,11 @@ metadata:
     uri: #@ data.values.invoker.url
     sha256: #@ data.values.invoker.sha
     stacks:
-    - io.buildpacks.stacks.bionic
+    - "*"
   - id: invoker-deps
     name: Python Invoker Deps
     version: #@ data.values.invoker_dep.version
     uri: #@ data.values.invoker_dep.url
     sha256: #@ data.values.invoker_dep.sha
     stacks:
-    - io.buildpacks.stacks.bionic
+    - "*"


### PR DESCRIPTION
This PR updates our Python and Java to use Buildpack API version 0.7 and will now target all stacks