### PR TITLE
Fetch the non-binary version of MarkupSafe

### DIFF
--- a/invokers/python/Dockerfile
+++ b/invokers/python/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /workspace/invoker
 RUN tox sdist
 RUN mkdir -p /out
 RUN cp /workspace/invoker/.tox/dist/*.tar.gz /out
-RUN pip download -d /workspace/dependencies .
+RUN pip download --no-binary 'MarkupSafe' -d /workspace/dependencies .
 RUN tar -cvzf /out/pyfunc-invoker-deps-$(cat /workspace/invoker/VERSION).tar.gz -C /workspace/dependencies .
 
 ENTRYPOINT [ "tox" ]


### PR DESCRIPTION
This addresses an issue where a version of python (non 3.9) is used and installing the dependency will cause it to fail.

This isn't seen if we are "online" but in an "offline" situation, this will fail to run our invoker.