### PR TITLE
feat(builder): Update buildpacks to support jammy stack

### DIFF
--- a/builder/ytt/builder.yaml
+++ b/builder/ytt/builder.yaml
@@ -7,6 +7,6 @@ order: []
 lifecycle:
   uri: https://github.com/buildpacks/lifecycle/releases/download/v0.14.1/lifecycle-v0.14.1+linux.x86-64.tgz
 stack:
-  id: io.buildpacks.stacks.bionic
-  build-image: gcr.io/paketo-buildpacks/build:0.0.97-base-cnb
-  run-image: gcr.io/paketo-buildpacks/run:base-cnb
+  id: io.buildpacks.stacks.jammy
+  build-image: paketobuildpacks/build-jammy-base:0.1.8
+  run-image: paketobuildpacks/run-jammy-base:0.1.8

--- a/builder/ytt/java.yaml
+++ b/builder/ytt/java.yaml
@@ -7,28 +7,11 @@
 #@overlay/match by=overlay.all
 ---
 buildpacks:
-- id: paketo-buildpacks/bellsoft-liberica
-  uri: docker://gcr.io/paketo-buildpacks/bellsoft-liberica:7.0.0
-- id: paketo-buildpacks/gradle
-  uri: docker://gcr.io/paketo-buildpacks/gradle:4.2.0
-- id: paketo-buildpacks/leiningen
-  uri: docker://gcr.io/paketo-buildpacks/leiningen:2.0.0
-- id: paketo-buildpacks/maven
-  uri: docker://gcr.io/paketo-buildpacks/maven:4.0.0
-- id: paketo-buildpacks/sbt
-  uri: docker://gcr.io/paketo-buildpacks/sbt:4.1.0
+- id: paketo-buildpacks/java
+  uri: docker://gcr.io/paketo-buildpacks/java:6.36.0
 - id: kn-fn/java-function
   uri: #@ data.values.java_function_buildpack.url
 order:
 - group:
-  - id: paketo-buildpacks/bellsoft-liberica
-  - id: paketo-buildpacks/gradle
-    optional: true
-  - id: paketo-buildpacks/leiningen
-    optional: true
-  - id: paketo-buildpacks/maven
-    optional: true
-  - id: paketo-buildpacks/sbt
-    optional: true
+  - id: paketo-buildpacks/java
   - id: kn-fn/java-function
-    optional: false

--- a/builder/ytt/nodejs.yaml
+++ b/builder/ytt/nodejs.yaml
@@ -8,7 +8,7 @@
 ---
 buildpacks:
 - id: paketo-buildpacks/nodejs
-  uri: docker://gcr.io/paketo-buildpacks/nodejs:0.0.10
+  uri: docker://gcr.io/paketo-buildpacks/nodejs:0.23.0
 order:
 - group:
   - id: paketo-buildpacks/nodejs

--- a/builder/ytt/python.yaml
+++ b/builder/ytt/python.yaml
@@ -7,11 +7,11 @@
 #@overlay/match by=overlay.all
 ---
 buildpacks:
-- id: paketo-community/python
-  uri: docker://gcr.io/paketo-community/python:0.7.0
+- id: paketo-buildpacks/python
+  uri: docker://gcr.io/paketo-buildpacks/python:2.0.0
 - id: kn-fn/python-function
   uri: #@ data.values.python_function_buildpack.url
 order:
 - group:
-  - id: paketo-community/python
+  - id: paketo-buildpacks/python
   - id: kn-fn/python-function

--- a/buildpacks/java/java/detect.go
+++ b/buildpacks/java/java/detect.go
@@ -61,7 +61,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				},
 			},
 			{
-				Name: "jvm-application",
+				Name: "jvm-application-package",
 			},
 		},
 	})


### PR DESCRIPTION
This change updates the builder to use latest versions of the buildpacks for Java, Python and NodeJS.
The builder's focus is now specifically functions, if the functions buildpack doesn't get activated this builder won't do anything. It's no longer intended for use to build plain ol java or python applications.

**We will need to first cut new invokers and new buildpacks to maybe have passing tests for this PR.**