### PR TITLE
fix(python-buildpack): add workaround for offline python-buildpack

### DIFF
--- a/buildpacks/python/python/invoker.go
+++ b/buildpacks/python/python/invoker.go
@@ -21,6 +21,7 @@ type Invoker struct {
 }
 
 func NewInvoker(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) Invoker {
+	dependency.CPEs = []string{}
 	contributor := libpak.NewDependencyLayerContributor(dependency, cache, libcnb.LayerTypes{
 		Launch: true,
 		Cache:  true,

--- a/buildpacks/python/python/invoker_dependency_cache.go
+++ b/buildpacks/python/python/invoker_dependency_cache.go
@@ -24,6 +24,7 @@ type InvokerDependencyCache struct {
 }
 
 func NewInvokerDependencyCache(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) InvokerDependencyCache {
+	dependency.CPEs = []string{}
 	contributor := libpak.NewDependencyLayerContributor(dependency, cache, libcnb.LayerTypes{
 		Launch: true,
 		Cache:  true,


### PR DESCRIPTION
The workaround addresses an issue with libpak where a comaprison fails because of a `nil` in the CPEs when none is specified.

https://github.com/paketo-buildpacks/libpak/issues/167