### PR TITLE
[WIP] fix(java-buildpack): add workaround for offline java-buildpack

### DIFF
--- a/buildpacks/java/java/invoker.go
+++ b/buildpacks/java/java/invoker.go
@@ -19,6 +19,7 @@ type Invoker struct {
 }
 
 func NewInvoker(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) (Invoker, libcnb.BOMEntry) {
+	dependency.CPEs = []string{}
 	contributor, entry := libpak.NewDependencyLayer(dependency, cache, libcnb.LayerTypes{
 		Launch: true,
 	})


### PR DESCRIPTION
The workaround addresses an issue with libpak where a comaprison fails because of a `nil` in the CPEs when none is specified.