### PR TITLE
fix(python-buildpack): Explicitly require python for build and launch

### DIFF
--- a/buildpacks/python/python/detect.go
+++ b/buildpacks/python/python/detect.go
@@ -62,6 +62,13 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 					"build": true,
 				},
 			},
+			{
+				Name: "cpython",
+				Metadata: map[string]interface{}{
+					"build":  true,
+					"launch": true,
+				},
+			},
 		},
 	})
 


### PR DESCRIPTION
One of the buildpacks we depend on looks like no longer transitively
include python at launch time. We will now be explicit in the required
buildpacks to prevent future breakage.