### PR TITLE
feat(python-buildpack): Add support for cycloneDX SBOM when available.

### DIFF
--- a/buildpacks/python/ytt/buildpack.yaml
+++ b/buildpacks/python/ytt/buildpack.yaml
@@ -10,6 +10,7 @@ buildpack:
   version: #@ data.values.buildpack.version
   sbom-formats:
   - application/vnd.syft+json
+  - application/vnd.cyclonedx+json
 stacks:
 - id: "*"
 metadata:


### PR DESCRIPTION
Libpak is working on adding support cycloneDX. Adding the SBOM format for the future.