### PR TITLE
chore(python-buildpack): Add CPEs and pURL to python buildpack dependencies

### DIFF
--- a/buildpacks/python/python/invoker.go
+++ b/buildpacks/python/python/invoker.go
@@ -21,7 +21,6 @@ type Invoker struct {
 }
 
 func NewInvoker(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) Invoker {
-	dependency.CPEs = []string{}
 	contributor := libpak.NewDependencyLayerContributor(dependency, cache, libcnb.LayerTypes{
 		Launch: true,
 		Cache:  true,

--- a/buildpacks/python/python/invoker_dependency_cache.go
+++ b/buildpacks/python/python/invoker_dependency_cache.go
@@ -24,7 +24,6 @@ type InvokerDependencyCache struct {
 }
 
 func NewInvokerDependencyCache(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) InvokerDependencyCache {
-	dependency.CPEs = []string{}
 	contributor := libpak.NewDependencyLayerContributor(dependency, cache, libcnb.LayerTypes{
 		Launch: true,
 		Cache:  true,

--- a/buildpacks/python/ytt/dependencies.yaml
+++ b/buildpacks/python/ytt/dependencies.yaml
@@ -15,6 +15,11 @@ metadata:
     sha256: #@ data.values.invoker.sha
     stacks:
     - "*"
+    purl: #@ "pkg:generic/pyfunc_invoker@{version}?checksum={sha}&download_url={url}".format(version=data.values.invoker.version, sha=data.values.invoker.sha, url=data.values.invoker.url)
+    licenses: [ BSD-2-Clause ]
+    cpes:
+    - #@ 'cpe:2.3:a:vmware:pyfunc_invoker:{version}:*:*:*:*:*:*:*'.format(version=data.values.invoker.version)
+
   - id: invoker-deps
     name: Python Invoker Deps
     version: #@ data.values.invoker_dep.version
@@ -22,3 +27,4 @@ metadata:
     sha256: #@ data.values.invoker_dep.sha
     stacks:
     - "*"
+    purl: #@ "pkg:generic/pyfunc_invoker_deps@{version}?checksum={sha}&download_url={url}".format(version=data.values.invoker_dep.version, sha=data.values.invoker_dep.sha, url=data.values.invoker_dep.url)

--- a/buildpacks/python/ytt/dependency-metadata.yaml
+++ b/buildpacks/python/ytt/dependency-metadata.yaml
@@ -1,0 +1,33 @@
+# Copyright 2021-2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+#! This is temporary. We should automate this section.
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.all
+---
+metadata:
+  dependencies:
+  #@overlay/match by="id"
+  - id: invoker-deps
+    #@overlay/match expects=0
+    licenses:
+    - BSD-3-Clause
+    - MIT
+    - Apache-2.0
+    - BSD-2-Clause or Apache-2.0
+    - ZPL-2.1
+    #@overlay/match expects=0
+    cpes:
+    - cpe:2.3:a:palletsproject:click:8.1.3:*:*:*:*:*:*:*
+    - cpe:2.3:a:palletsproject:flask:2.2.2:*:*:*:*:*:*:*
+    - cpe:2.3:a:palletsproject:itsdangerous:2.1.2:*:*:*:*:*:*:*
+    - cpe:2.3:a:palletsproject:jinja2:3.1.2:*:*:*:*:*:*:*
+    - cpe:2.3:a:palletsproject:markupsafe:2.1.1:*:*:*:*:*:*:*
+    - cpe:2.3:a:palletsproject:werkzeug:2.2.2:*:*:*:*:*:*:*
+    - cpe:2.3:a:agendaless:waitress:2.1.2:*:*:*:*:*:*:*
+    - cpe:2.3:a:fedora-infrastructure:0.0.3:*:*:*:*:*:*:*
+    - cpe:2.3:a:pyparsing:pyparsing:3.0.9:*:*:*:*:*:*:*
+    - cpe:2.3:a:pypa:packaging:21.3:*:*:*:*:*:*:*
+    - cpe:2.3:a:cloudevents:sdk-python:1.6.1:*:*:*:*:*:*:*
+    - cpe:2.3:a:brian_curtin:deprecation:2.1.0:*:*:*:*:*:*:*


### PR DESCRIPTION
This removes the workaround/hack for the libpak bug. Added CPEs and pURL for the python dependencies we pull in. We are currently doing it manually but we should automate this at some point.