### PR TITLE
chore(python-buildpack): Remove unnecessary entrypoint

### DIFF
--- a/buildpacks/python/python/build.go
+++ b/buildpacks/python/python/build.go
@@ -98,10 +98,6 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			Command:   command,
 			Arguments: arguments,
 		},
-		libcnb.Process{
-			Type:    "shell",
-			Command: "bash",
-		},
 	)
 
 	return result, nil


### PR DESCRIPTION
The `shell` entrypoint was meant for debugging, use the following commands to achieve the same result:

`docker run -it --entrypoint launcher <image_name> /bin/bash`

