### PR TITLE
fix(java-buildpack): `jvm-application` has been renamed to `jvm-application-package`

### DIFF
--- a/buildpacks/java/java/detect.go
+++ b/buildpacks/java/java/detect.go
@@ -61,7 +61,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				},
 			},
 			{
-				Name: "jvm-application",
+				Name: "jvm-application-package",
 			},
 		},
 	})


### PR DESCRIPTION
This was something we never noticed when testing with our builder. In newer versions of the Java buildpacks, the gradle and maven buildpacks provide `jvm-application-package` instead of `jvm-application`. 