### PR TITLE
Make contributing a bit easier/clearer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 bin/
 out/
 tools/
+local.mk
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,14 @@ The function-buildpacks-for-knative project is organized into "layers" that sum 
 
 The `invokers` layer is the lowest level, followed by `buildpacks`, then lastly the `builder` references the `buildpacks` by URI and SHA at the highest level. To learn more about each layer, you may read the `README` for each respective layer's directory.
 
-New additions to the `samples/` and `templates/` directories are welcome -- each directory also has information about usage and testing. We can only accept PRs for these that DO NOT include imports from unvetted repositories or infringing licenses. Please keep them as lightweight and templateable as possible.
-
-> ⚠️ You will need to set your own registry you can read/write to in [rules.mk](https://github.com/vmware-tanzu/function-buildpacks-for-knative/blob/f247b62ff9bcd3ac4f31d495f7630b4904a193cf/rules.mk#L25).
+New additions to the `samples/` and `templates/` directories are welcome -- each directory also has information about usage and testing. We can only accept PRs for these that DO NOT include imports from unvetted repositories or infringing licenses. Please keep them as lightweight and template-able as possible.
 
 To deploy your work, see [DEPLOYING](DEPLOYING.md).
 
-To test your work, run `make tests`, visit the `tests/` directory, or read the `Makefile` to view all available commands. We will not accept PRs that fail any tests. If you are including any feature additions, templates, samples, or breaking changes, it is expected that a corresponding test will be added.
+To learn how to test your work, read the [testing documentation](/tests/README.md). We will not accept PRs that fail any tests. If you are including any feature additions, templates, samples, or breaking changes, it is expected that a corresponding test will be added.
 
+> **Note:** To use your own registry for local development and tests, copy and edit [local.example.mk](/local.example.mk) to set the registry to one for which you have read/write access.
+> Be sure to also run `make clean` any time you adjust the registry value.
 
 ## Contribution Flow
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ tests:
 buildpacks.tests:
 invokers.tests:
 smoke-tests:
+template-tests:
 
 clean:
 

--- a/local.example.mk
+++ b/local.example.mk
@@ -1,0 +1,6 @@
+# NOTE: Copy this file and rename to `local.mk`, then make necessary adjustments.
+
+# IMPORTANT: Run `make clean` after adjustments to registry location.
+registry.location := local
+# registry.location := other  # alternative - requires `REGISTRY` env var to be set.
+registry.local := example.com/registry

--- a/rules.mk
+++ b/rules.mk
@@ -3,6 +3,8 @@ RULES_MK := $(lastword $(MAKEFILE_LIST))
 RULES_INCLUDE_DIR := $(dir $(RULES_MK))
 ROOT_DIR := $(RULES_INCLUDE_DIR)
 
+-include $(ROOT_DIR)/local.mk
+
 .DEFAULT_GOAL := all
 .DELETE_ON_ERROR: # This will delete files from targets that don't succeed.
 .SUFFIXES: # This removes a lot of the implicit rules.
@@ -23,14 +25,14 @@ git.commit := $(shell git rev-parse HEAD)
 
 base_url := https://github.com/vmware-tanzu/function-buildpacks-for-knative
 
-registry.location := gcr
-registry.gcr := us.gcr.io/daisy-284300/kn-fn
+registry.location ?= ghcr
+registry.ghcr := ghcr.io/vmware-tanzu/function-buildpacks-for-knative
 registry.other := $(REGISTRY)
 registry = $(registry.$(registry.location))
 
 ifeq ($(registry.location), other)
 ifndef REGISTRY
-$(error REGISTRY not defined. This is required for targetting "other" registry)
+$(error REGISTRY not defined. This is required for targeting "other" registry)
 endif
 endif
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,10 @@
 # Tests
 
-To run the smoke tests, run `make smoke-tests` from this directory.
+To run the smoke tests, run `make smoke-tests`.
+
+To run template tests, run `make template-tests`.
+
+Or to run all tests, run `make tests`.
 
 ## Adding Tests
 


### PR DESCRIPTION
- Updates default registry location to one that will work when running `make tests` out of the gate
- Adds ability to easily override registry location with local config (that isn't version-controlled) via a `local.mk` file
- Updates docs for clarity