### PR TITLE
fix(java-buildpack): update CPE for java-buildpack

### DIFF
--- a/buildpacks/java/ytt/dependency-metadata.yaml
+++ b/buildpacks/java/ytt/dependency-metadata.yaml
@@ -14,5 +14,5 @@ metadata:
     - cpe:2.3:a:spring_cloud:spring_boot_starter_parent:2.7.3:*:*:*:*:*:*:*
     - cpe:2.3:a:spring_cloud:spring_boot_starter_actuator:2.7.3:*:*:*:*:*:*:*
     - cpe:2.3:a:spring_cloud:spring_boot_starter_web:2.7.3:*:*:*:*:*:*:*
-    - cpe:2.3:a:vmware:spring_cloud_function_deployer::3.2.6:*:*:*:*:*:*:*
-    - cpe:2.3:a:vmware:spring_cloud_function_web::3.2.6:*:*:*:*:*:*:*
+    - cpe:2.3:a:vmware:spring_cloud_function_deployer::3.2.8:*:*:*:*:*:*:*
+    - cpe:2.3:a:vmware:spring_cloud_function_web::3.2.8:*:*:*:*:*:*:*


### PR DESCRIPTION
I forgot to update this when I bumped the version. We should see if we can automate this eventually.