### PR TITLE
Remove dependency on knative dev pkg in the buildpack tests

### DIFF
--- a/buildpacks/common/go.mod
+++ b/buildpacks/common/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/paketo-buildpacks/libpak v1.63.0
 	gopkg.in/yaml.v3 v3.0.1
 	knative.dev/kn-plugin-func v0.19.0
-	knative.dev/pkg v0.0.0-20221010143036-21d3b47e2efe
 )
 
 require (

--- a/buildpacks/common/tests/func_yaml_test.go
+++ b/buildpacks/common/tests/func_yaml_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	"k8s.io/utils/pointer"
 	knfn "knative.dev/kn-plugin-func"
-	"knative.dev/pkg/ptr"
 
 	"kn-fn/buildpacks/config"
 )
@@ -59,11 +59,11 @@ func TestParseFuncYaml_HasEnvs(t *testing.T) {
 
 func TestParseFuncYaml_HasScale(t *testing.T) {
 	scaleOption := knfn.ScaleOptions{
-		Min:         ptr.Int64(4),
-		Max:         ptr.Int64(9),
-		Metric:      ptr.String("rps"),
-		Target:      ptr.Float64(0.5),
-		Utilization: ptr.Float64(50),
+		Min:         pointer.Int64(4),
+		Max:         pointer.Int64(9),
+		Metric:      pointer.String("rps"),
+		Target:      pointer.Float64(0.5),
+		Utilization: pointer.Float64(50),
 	}
 
 	appDir, cleanup := SetupTestDirectory(WithFuncScale(scaleOption))
@@ -96,8 +96,8 @@ func TestParseFuncYaml_HasScale(t *testing.T) {
 
 func TestParseFuncYaml_HasRequests(t *testing.T) {
 	requestOptions := knfn.ResourcesRequestsOptions{
-		CPU:    ptr.String("1"),
-		Memory: ptr.String("40m"),
+		CPU:    pointer.String("1"),
+		Memory: pointer.String("40m"),
 	}
 
 	appDir, cleanup := SetupTestDirectory(WithFuncResourceRequests(requestOptions))
@@ -118,9 +118,9 @@ func TestParseFuncYaml_HasRequests(t *testing.T) {
 
 func TestParseFuncYaml_HasLimits(t *testing.T) {
 	limitOptions := knfn.ResourcesLimitsOptions{
-		CPU:         ptr.String("1"),
-		Memory:      ptr.String("40m"),
-		Concurrency: ptr.Int64(5),
+		CPU:         pointer.String("1"),
+		Memory:      pointer.String("40m"),
+		Concurrency: pointer.Int64(5),
 	}
 
 	appDir, cleanup := SetupTestDirectory(WithFuncResourceLimits(limitOptions))

--- a/buildpacks/java/go.mod
+++ b/buildpacks/java/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/sclevine/spec v1.4.0
 	kn-fn/buildpacks v0.0.0
 	knative.dev/kn-plugin-func v0.19.0
-	knative.dev/pkg v0.0.0-20221010143036-21d3b47e2efe
 )
 
 require (

--- a/buildpacks/java/tests/detect_test.go
+++ b/buildpacks/java/tests/detect_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+	"k8s.io/utils/pointer"
 	function "knative.dev/kn-plugin-func"
-	"knative.dev/pkg/ptr"
 
 	"kn-fn/buildpacks/tests"
 	"kn-fn/java-function-buildpack/java"
@@ -114,8 +114,8 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 					"SOME_VAR": "SOME_VALUE",
 				}),
 				tests.WithFuncScale(function.ScaleOptions{
-					Min: ptr.Int64(1),
-					Max: ptr.Int64(42),
+					Min: pointer.Int64(1),
+					Max: pointer.Int64(42),
 				}),
 			)
 			context = makeDetectContext(

--- a/buildpacks/python/go.mod
+++ b/buildpacks/python/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/sclevine/spec v1.4.0
 	kn-fn/buildpacks v0.0.0
 	knative.dev/kn-plugin-func v0.19.0
-	knative.dev/pkg v0.0.0-20221010143036-21d3b47e2efe
 )
 
 require (

--- a/buildpacks/python/tests/detect_test.go
+++ b/buildpacks/python/tests/detect_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+	"k8s.io/utils/pointer"
 	function "knative.dev/kn-plugin-func"
-	"knative.dev/pkg/ptr"
 
 	"kn-fn/buildpacks/tests"
 	"kn-fn/python-function-buildpack/python"
@@ -132,8 +132,8 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 						"SOME_VAR": "SOME_VALUE",
 					}),
 					tests.WithFuncScale(function.ScaleOptions{
-						Min: ptr.Int64(1),
-						Max: ptr.Int64(42),
+						Min: pointer.Int64(1),
+						Max: pointer.Int64(42),
 					}),
 				)
 				context = makeDetectContext(


### PR DESCRIPTION
Remove dependency on knative dev pkg in the buildpack tests

Signed-off-by: Joe Eltgroth <jeltgroth@vmware.com>