### PR TITLE
fix(java-buildpack): Treat empty BP_FUNCTION the same as unset

### DIFF
--- a/buildpacks/java/java/detect.go
+++ b/buildpacks/java/java/detect.go
@@ -18,7 +18,7 @@ type Detect struct {
 }
 
 func (d Detect) checkConfigs(cr libpak.ConfigurationResolver) bool {
-	if _, defined := cr.Resolve("BP_FUNCTION"); defined {
+	if val, defined := cr.Resolve("BP_FUNCTION"); defined && val != "" {
 		return true
 	}
 

--- a/buildpacks/java/tests/detect_test.go
+++ b/buildpacks/java/tests/detect_test.go
@@ -90,7 +90,21 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 
 		when("BP_FUNCTION is not configured", func() {
 			it.Before(func() {
-				Expect(os.Unsetenv("BP_FUNCTION")).To(Succeed())
+				t.Setenv("BP_FUNCTION", "")
+				Expect(os.Unsetenv("BP_FUNCTION")).To(Succeed()) // needed in combination with above, so original value will be restored
+			})
+
+			it("fails detection", func() {
+				result, err := detect.Detect(context)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result.Pass).To(BeFalse())
+			})
+		})
+
+		when("BP_FUNCTION is empty", func() {
+			it.Before(func() {
+				t.Setenv("BP_FUNCTION", "")
 			})
 
 			it("fails detection", func() {


### PR DESCRIPTION
Fixes a small area in the java buildpack tests where we neglected to use the testing-specific `t.Setenv` (note the `t.`). We were using `os.Unsetenv` instead (note the `os.`). This also leads us to treat an empty env var similarly to an unset env var -- which is good to do anyway -- because there is no `t.Unsetenv()` and we have to use `t.Setenv(..., "")` instead.

For the curious, here's a thread on the reasoning behind no `t.Unsetenv`: https://github.com/golang/go/issues/52817. Essentially, the argument is that it's unnecessary because `t.Setenv(..., "")` should be used instead (and empty vars should be treated like unset vars).