### PR TITLE
chore(template-tests): generate symlinks at test time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tests/testdata/template_and_smoke/template-*
 .DS_Store
 .idea
 .vscode

--- a/rules.mk
+++ b/rules.mk
@@ -1,7 +1,7 @@
 ifndef RULES_MK # Prevent repeated "-include".
 RULES_MK := $(lastword $(MAKEFILE_LIST))
 RULES_INCLUDE_DIR := $(dir $(RULES_MK))
-ROOT_DIR := $(RULES_INCLUDE_DIR)
+ROOT_DIR := $(abspath $(RULES_INCLUDE_DIR))
 
 -include $(ROOT_DIR)/local.mk
 

--- a/tests/testdata/template_and_smoke/template-ce/Makefile
+++ b/tests/testdata/template_and_smoke/template-ce/Makefile
@@ -1,4 +1,4 @@
-RULES.MK ?= ../../../rules.mk
+RULES.MK ?= ../../../../rules.mk
 include $(RULES.MK)
 
 path ?= .
@@ -6,18 +6,27 @@ template-ce.path := $(abspath $(path))
 
 $(eval $(call INCLUDE_FILE, $(ROOT_DIR)/builder))
 
-template-ce.image := kn-fn-test/template-ce
-template-ce.java_image_paths := $(shell find $(template-ce.path) -mindepth 1 -maxdepth 1 -type l | grep java-)
-template-ce.python_image_paths := $(shell find $(template-ce.path) -mindepth 1 -maxdepth 1 -type l | grep python-)
-$(template-ce.java_image_paths): $(PACK) $(builder.image.out)
-	cd $@ && $(PACK) build $(template-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=functions.Handler --pull-policy if-not-present --clear-cache
-$(template-ce.python_image_paths): $(PACK) $(builder.image.out)
-	cd $@ && $(PACK) build $(template-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=func.main --pull-policy if-not-present --clear-cache
+template-ce.templates.langs := $(filter-out %/README.md, $(wildcard $(abspath $(ROOT_DIR)/templates)/*))
+template-ce.sources := $(foreach lang, $(template-ce.templates.langs), $(addprefix $(lang)/, $(filter cloudevents%, $(notdir $(wildcard $(lang)/*)))))
+template-ce.dest := $(addprefix $(template-ce.path)/, $(foreach lang,$(template-ce.templates.langs),$(addprefix $(notdir $(lang))-, $(filter cloudevents%, $(notdir $(wildcard $(lang)/*))))))
 
-template-ce.clean := $(addsuffix .clean,$(template-ce.image_paths))
+template-ce.out := $(addprefix $(out_dir)/tests/template/,$(notdir $(template-ce.dest)))
+
+template-ce.java.bp_function := functions.Handler
+template-ce.python.bp_function := func.main
+
+.SECONDEXPANSION:
+$(template-ce.path)/%: $$(foreach v,%, $$(addprefix $(ROOT_DIR)/templates/,$$(firstword $$(subst -, ,$$(v)))/$$(subst $$(firstword $$(subst -, ,$$(v)))-,,$$(v))))
+	ln -sf $< $@
+
+$(template-ce.out): $(out_dir)/tests/template/%: $(template-ce.path)/% $(PACK) $(builder.image.out)
+	cd $< && $(PACK) build $(template-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=$(template-ce.$(firstword $(subst -, ,$*)).bp_function) --pull-policy if-not-present --clear-cache
+
+template-ce.image := kn-fn-test/template-ce
+template-ce.clean := $(addsuffix .clean,$(template-ce.out))
 $(template-ce.clean):
 	-docker rmi -f $(template-ce.image):$(basename $(notdir $@))
 
 .PHONY: template-tests.images
-template-tests.images .PHONY: $(template-ce.java_image_paths) $(template-ce.python_image_paths)
+template-tests.images .PHONY: $(template-ce.out)
 clean .PHONY: $(template-ce.clean)

--- a/tests/testdata/template_and_smoke/template-ce/java-cloudevents-gradle
+++ b/tests/testdata/template_and_smoke/template-ce/java-cloudevents-gradle
@@ -1,1 +1,0 @@
-../../../../templates/java/cloudevents-gradle/

--- a/tests/testdata/template_and_smoke/template-ce/java-cloudevents-maven
+++ b/tests/testdata/template_and_smoke/template-ce/java-cloudevents-maven
@@ -1,1 +1,0 @@
-../../../../templates/java/cloudevents-maven/

--- a/tests/testdata/template_and_smoke/template-ce/python-cloudevents
+++ b/tests/testdata/template_and_smoke/template-ce/python-cloudevents
@@ -1,1 +1,0 @@
-../../../../templates/python/cloudevents/

--- a/tests/testdata/template_and_smoke/template-http/Makefile
+++ b/tests/testdata/template_and_smoke/template-http/Makefile
@@ -1,4 +1,4 @@
-RULES.MK ?= ../../../rules.mk
+RULES.MK ?= ../../../../rules.mk
 include $(RULES.MK)
 
 path ?= .
@@ -6,18 +6,27 @@ template-http.path := $(abspath $(path))
 
 $(eval $(call INCLUDE_FILE, $(ROOT_DIR)/builder))
 
-template-http.image := kn-fn-test/template-http
-template-http.java_image_paths := $(shell find $(template-http.path) -mindepth 1 -maxdepth 1 -type l | grep java-)
-template-http.python_image_paths := $(shell find $(template-http.path) -mindepth 1 -maxdepth 1 -type l | grep python-)
-$(template-http.java_image_paths): $(PACK) $(builder.image.out)
-	cd $@ && $(PACK) build $(template-http.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=functions.Handler --pull-policy if-not-present --clear-cache
-$(template-http.python_image_paths): $(PACK) $(builder.image.out)
-	cd $@ && $(PACK) build $(template-http.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=func.main --pull-policy if-not-present --clear-cache
+template-http.templates.langs := $(filter-out %/README.md, $(wildcard $(abspath $(ROOT_DIR)/templates)/*))
+template-http.sources := $(foreach lang, $(template-http.templates.langs), $(addprefix $(lang)/, $(filter http%, $(notdir $(wildcard $(lang)/*)))))
+template-http.dest := $(addprefix $(template-http.path)/, $(foreach lang,$(template-http.templates.langs),$(addprefix $(notdir $(lang))-, $(filter http%, $(notdir $(wildcard $(lang)/*))))))
 
-template-http.clean := $(addsuffix .clean,$(template-http.image_paths))
+template-http.out := $(addprefix $(out_dir)/tests/template/,$(notdir $(template-http.dest)))
+
+template-http.java.bp_function := functions.Handler
+template-http.python.bp_function := func.main
+
+.SECONDEXPANSION:
+$(template-http.path)/%: $$(foreach v,%, $$(addprefix $(ROOT_DIR)/templates/,$$(firstword $$(subst -, ,$$(v)))/$$(subst $$(firstword $$(subst -, ,$$(v)))-,,$$(v))))
+	ln -sf $< $@
+
+$(template-http.out): $(out_dir)/tests/template/%: $(template-http.path)/% $(PACK) $(builder.image.out)
+	cd $< && $(PACK) build $(template-http.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=$(template-http.$(firstword $(subst -, ,$*)).bp_function) --pull-policy if-not-present --clear-cache
+
+template-http.image := kn-fn-test/template-http
+template-http.clean := $(addsuffix .clean,$(template-http.out))
 $(template-http.clean):
 	-docker rmi -f $(template-http.image):$(basename $(notdir $@))
 
 .PHONY: template-tests.images
-template-tests.images .PHONY: $(template-http.java_image_paths) $(template-http.python_image_paths)
+template-tests.images .PHONY: $(template-http.out)
 clean .PHONY: $(template-http.clean)

--- a/tests/testdata/template_and_smoke/template-http/java-http-gradle
+++ b/tests/testdata/template_and_smoke/template-http/java-http-gradle
@@ -1,1 +1,0 @@
-../../../../templates/java/http-gradle/

--- a/tests/testdata/template_and_smoke/template-http/java-http-maven
+++ b/tests/testdata/template_and_smoke/template-http/java-http-maven
@@ -1,1 +1,0 @@
-../../../../templates/java/http-maven/

--- a/tests/testdata/template_and_smoke/template-http/python-http
+++ b/tests/testdata/template_and_smoke/template-http/python-http
@@ -1,1 +1,0 @@
-../../../../templates/python/http/


### PR DESCRIPTION
To work with the knative func CLI for our templates, there is a bug where a symlink to a directory will cause it to fail cloning our templates.

This will address that issue for now, as we'll generate these symlinks at test time only.