### PR TITLE
specify buildpack images instead of builder

### DIFF
--- a/templates/java/manifest.yaml
+++ b/templates/java/manifest.yaml
@@ -5,7 +5,7 @@ buildpacks:
 - gcr.io/paketo-buildpacks/java:6.36.0
 - ghcr.io/vmware-tanzu/function-buildpacks-for-knative/java-buildpack:1.0.7
 builderImages:
-  pack: gcr.io/paketo-buildpacks/builder:base
+  pack: gcr.io/paketo-buildpacks/builder:buildpackless-full
 
 buildEnvs:
 - name: BP_FUNCTION

--- a/templates/java/manifest.yaml
+++ b/templates/java/manifest.yaml
@@ -1,8 +1,11 @@
 # Copyright 2021-2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
+buildpacks:
+- gcr.io/paketo-buildpacks/java:6.36.0
+- ghcr.io/vmware-tanzu/function-buildpacks-for-knative/java-buildpack:1.0.7
 builderImages:
-  pack: ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.2.0
+  pack: gcr.io/paketo-buildpacks/builder:base
 
 buildEnvs:
 - name: BP_FUNCTION

--- a/templates/python/manifest.yaml
+++ b/templates/python/manifest.yaml
@@ -4,6 +4,8 @@
 buildpacks:
 - gcr.io/paketo-buildpacks/python:2.0.0
 - ghcr.io/vmware-tanzu/function-buildpacks-for-knative/python-buildpack-with-deps:1.1.0
+builderImages:
+  pack: gcr.io/paketo-buildpacks/builder:buildpackless-full
 
 buildEnvs:
 - name: BP_FUNCTION

--- a/templates/python/manifest.yaml
+++ b/templates/python/manifest.yaml
@@ -1,8 +1,9 @@
 # Copyright 2021-2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
-builderImages:
-  pack: ghcr.io/vmware-tanzu/function-buildpacks-for-knative/functions-builder:0.2.0
+buildpacks:
+- gcr.io/paketo-buildpacks/python:2.0.0
+- ghcr.io/vmware-tanzu/function-buildpacks-for-knative/python-buildpack-with-deps:1.1.0
 
 buildEnvs:
 - name: BP_FUNCTION


### PR DESCRIPTION
## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Please open an issue first, if none exists.
-->
Fixes: #23 

## What this PR solves
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
Makes Java and Python templates compatible with kn-func cli plugin
## Details for release notes
<!--
Unless this is a trivial change, we want to know more about your contribution!
This can even be a TLDR version of the "What this PR does".
If a trivial change, just write "NONE" in the release-note block below.
Otherwise, a release note is required:
-->
```release-note
Replace buildpack builder in Java and Python func templates to use buildpacks images with default builder
```

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->
Built images from templates with the latest version of kn-func plugin

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR. You can also @mention a reviewer here, if needed.

Example: Please verify how I handled foo aligns with overall plan.
-->
The Java template requires the builder image to be specified because there's no default image for the `java` runtime if we wanted for the template to use the default builder without setting it in the template's manifest we should rename the folder to what the func plugin expects `springboot`
