### PR TITLE
chore(docs): Provide documentation on cutting a release

### DIFF
--- a/invokers/README.md
+++ b/invokers/README.md
@@ -25,3 +25,24 @@ After making your changes to your Invoker's files:
 5) Locally build your function with this new builder (`make builder.clean` if needed, then `make builder`)
 
 All of these processes can be explored with a further dive into the `Makefile`'s of each component.
+
+### Cut a Buildpack Release After Modifying Invokers
+
+To build new versioned invokers:  
+
+1. Test (as discussed above) and commit your changes to the main branch. Observe successful checks on the PR. 
+1. Via the Github web UI navigate to Actions and  
+   choose [Create Invoker Release](https://github.com/vmware-tanzu/function-buildpacks-for-knative/actions/workflows/create-invoker-release.yaml)
+1. Click "Run Workflow", choose the language and the type of release. This will result in the action making a commit that changes the invoker's VERSION file. 
+
+To build a new versioned buildpack: 
+1. If necessary, update the cpe versions in buildpacks/<language>/ytt/dependency-metadata.yaml where <language> is java or python. 
+1. Choose [Create Buildpack Release](https://github.com/vmware-tanzu/function-buildpacks-for-knative/actions/workflows/create-buildpack-release.yaml)
+1. Click "Run Workflow", choose the language and type of release. 
+   This will create a commit that updates buildpacks/<language>/VERSION and buildpacks/<language>/buildpack.toml
+
+Update the builder: 
+1. Choose [Create Builder Release](https://github.com/vmware-tanzu/function-buildpacks-for-knative/actions/workflows/create-builder-release.yaml)
+1. Click "Run Workflow" and choose the type of release.  This will create a commit that updates builder/VERSION. 
+1. Search through documentation files for `pack build` commands that reference the version of the builder. Update
+   the builder version to the new builder's version. 


### PR DESCRIPTION
Provides documentation on how to cut an official release of invokers, buildpack, and builder images. 

Signed-off-by: Joe Eltgroth <jeltgroth@vmware.com>