### PR TITLE
Fix script injection attacks

### DIFF
--- a/.github/actions/semver-bump/.gitignore
+++ b/.github/actions/semver-bump/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-dist

--- a/.github/workflows/create-builder-release.yaml
+++ b/.github/workflows/create-builder-release.yaml
@@ -43,31 +43,44 @@ jobs:
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
       - name: Bump Version
+        env:
+          version: "${{ steps.version.outputs.version }}"
         run: |
-          printf "${{ steps.version.outputs.version }}" > ./builder/VERSION
+          printf $version > ./builder/VERSION
       - name: Run Smoke Tests
+        env:
+          base_url: "${{ env.DEPENDENCY_BASE_URL }}"
+          registry: "${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }}"
         run: |
-          make base_url=${{ env.DEPENDENCY_BASE_URL }} registry.location=other REGISTRY=${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} smoke-tests
+          make base_url=$base_url registry.location=other REGISTRY=$registry smoke-tests
       - name: Publish Container
+        env:
+          base_url: "${{ env.DEPENDENCY_BASE_URL }}"
+          registry: "${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }}"
         run: |
-          make base_url=${{ env.DEPENDENCY_BASE_URL }} registry.location=other REGISTRY=${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} builder.publish
+          make base_url=$base_url registry.location=other REGISTRY=$registry builder.publish
       - name: Commit Version
+        env:
+          version_file: "./builder/VERSION"
+          message: "Update builder version to ${{ steps.version.outputs.version }}"
         run: |
-          git add ./builder/VERSION
+          git add $version_file
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m 'Update builder version to ${{ steps.version.outputs.version }}'
+          git commit -m "${message}"
           git push
       - name: Create Tag
         id: tag
+        env:
+          tag: "builder/v${{ steps.version.outputs.version }}"
         run: |
-          tag=builder/v${{ steps.version.outputs.version }}
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"
       - id: artifacts
+        env:
+          image_file: ./out/builder/${{ steps.version.outputs.version }}/builder.image
         run: |
-          image_file=./out/builder/${{ steps.version.outputs.version }}/builder.image
           echo "::set-output name=image_file::${image_file}"
           echo "::set-output name=image_file_content::$(head ${image_file})"
           echo "::set-output name=image_sha_file::${image_file}.sha256"

--- a/.github/workflows/create-buildpack-release.yaml
+++ b/.github/workflows/create-buildpack-release.yaml
@@ -53,44 +53,51 @@ jobs:
           path: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
+          version: ${{ steps.version.outputs.version }}
       - name: Bump Version
         run: |
-          version="${{ steps.version.outputs.version }}"
-          version_location_output="./buildpacks/${{ github.event.inputs.buildpack }}/VERSION"
-          printf  $version > $version_location_output
+            printf  $version > $path
       - name: Run Tests
+        with:
+          target: buildpacks.${{ github.event.inputs.buildpack }}.tests
         run: |
-          target="buildpacks.${{ github.event.inputs.buildpack }}.tests"
           make $target
       - name: Publish Container
+        with:
+          url: ${{ env.DEPENDENCY_BASE_URL }}
+          registry: ${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} buildpacks.${{ github.event.inputs.buildpack }}.images.publish
         run: |
-          base_url="${{ env.DEPENDENCY_BASE_URL }}"
-          registry="${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} buildpacks.${{ github.event.inputs.buildpack }}.images.publish"
-          make base_url=$base_url registry.location=other REGISTRY=$registry
+          make base_url=$url registry.location=other REGISTRY=$registry
       - name: Prepare Commit
+        with:
+          target: buildpacks.${{ github.event.inputs.buildpack }}.commit.prep
         run: |
-          target="buildpacks.${{ github.event.inputs.buildpack }}.commit.prep"
           make $target
       - name: Commit
+        with:
+          version: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
+          buildpack: ./buildpacks/${{ github.event.inputs.buildpack }}/buildpack.toml
+          message: Update ${{ github.event.inputs.buildpack }} buildpack version to ${{ steps.version.outputs.version }}
         run: |
-          git add ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
-          git add ./buildpacks/${{ github.event.inputs.buildpack }}/buildpack.toml
+          git add $version
+          git add $buildpack
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m 'Update ${{ github.event.inputs.buildpack }} buildpack version to ${{ steps.version.outputs.version }}'
+          git commit -m '$message'
           git push
       - name: Create Tag
         id: tag
+        with:
+          tag: ${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}
         run: |
-          tag="${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}"
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"
       - id: artifacts
+        with:
+          online_image_file: ./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-${{ steps.version.outputs.version }}.image
+          offline_image_file: ./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-with-deps-${{ steps.version.outputs.version }}.image
         run: |
-          online_image_file=./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-${{ steps.version.outputs.version }}.image
-          offline_image_file=./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-with-deps-${{ steps.version.outputs.version }}.image
-
           echo "::set-output name=online_image_file::${online_image_file}"
           echo "::set-output name=online_image_file_content::$(head ${online_image_file})"
           echo "::set-output name=online_image_sha_file::${online_image_file}.sha256"

--- a/.github/workflows/create-buildpack-release.yaml
+++ b/.github/workflows/create-buildpack-release.yaml
@@ -53,10 +53,10 @@ jobs:
           path: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
-        env:
-          path: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
-          version: ${{ steps.version.outputs.version }}
       - name: Bump Version
+        env:
+          path: "./buildpacks/${{ github.event.inputs.buildpack }}/VERSION"
+          version: "${{ steps.version.outputs.version }}"
         run: |
           printf  $version > $path
       - name: Run Tests
@@ -67,9 +67,10 @@ jobs:
       - name: Publish Container
         env:
           url: ${{ env.DEPENDENCY_BASE_URL }}
-          registry: ${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} buildpacks.${{ github.event.inputs.buildpack }}.images.publish
+          registry: "${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }}"
+          target: "buildpacks.${{ github.event.inputs.buildpack }}.images.publish"
         run: |
-          make base_url=$url registry.location=other REGISTRY=$registry
+          make base_url=$url registry.location=other REGISTRY=$registry $target
       - name: Prepare Commit
         env:
           target: buildpacks.${{ github.event.inputs.buildpack }}.commit.prep
@@ -77,24 +78,24 @@ jobs:
           make $target
       - name: Commit
         env:
-          version: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
-          buildpack: ./buildpacks/${{ github.event.inputs.buildpack }}/buildpack.toml
-          message: Update ${{ github.event.inputs.buildpack }} buildpack version to ${{ steps.version.outputs.version }}
+          version: "./buildpacks/${{ github.event.inputs.buildpack }}/VERSION"
+          buildpack: "./buildpacks/${{ github.event.inputs.buildpack }}/buildpack.toml"
+          message: "Update ${{ github.event.inputs.buildpack }} buildpack version to ${{ steps.version.outputs.version }}"
         run: |
           git add $version
           git add $buildpack
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m '$message'
+          git commit -m "${message}"
           git push
       - name: Create Tag
         id: tag
         env:
-          tag: ${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}
+          tag: "${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}"
         run: |
           git tag $tag
           git push --tags
-          echo "::set-output name=tag::$tag"
+          echo "::set-output name=tag::${tag}"
       - id: artifacts
         env:
           online_image_file: ./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-${{ steps.version.outputs.version }}.image

--- a/.github/workflows/create-buildpack-release.yaml
+++ b/.github/workflows/create-buildpack-release.yaml
@@ -55,16 +55,22 @@ jobs:
           pre-release: ${{ github.event.inputs.pre-release-label }}
       - name: Bump Version
         run: |
-          printf "${{ steps.version.outputs.version }}" > ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
+          version="${{ steps.version.outputs.version }}"
+          version_location_output="./buildpacks/${{ github.event.inputs.buildpack }}/VERSION"
+          printf  $version > $version_location_output
       - name: Run Tests
         run: |
-          make buildpacks.${{ github.event.inputs.buildpack }}.tests
+          target="buildpacks.${{ github.event.inputs.buildpack }}.tests"
+          make $target
       - name: Publish Container
         run: |
-          make base_url=${{ env.DEPENDENCY_BASE_URL }} registry.location=other REGISTRY=${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} buildpacks.${{ github.event.inputs.buildpack }}.images.publish
+          base_url="${{ env.DEPENDENCY_BASE_URL }}"
+          registry="${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} buildpacks.${{ github.event.inputs.buildpack }}.images.publish"
+          make base_url=$base_url registry.location=other REGISTRY=$registry
       - name: Prepare Commit
         run: |
-          make buildpacks.${{ github.event.inputs.buildpack }}.commit.prep
+          target="buildpacks.${{ github.event.inputs.buildpack }}.commit.prep"
+          make $target
       - name: Commit
         run: |
           git add ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
@@ -76,7 +82,7 @@ jobs:
       - name: Create Tag
         id: tag
         run: |
-          tag=${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}
+          tag="${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}"
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"

--- a/.github/workflows/create-buildpack-release.yaml
+++ b/.github/workflows/create-buildpack-release.yaml
@@ -53,28 +53,30 @@ jobs:
           path: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
+        env:
+          path: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
           version: ${{ steps.version.outputs.version }}
       - name: Bump Version
         run: |
             printf  $version > $path
       - name: Run Tests
-        with:
+        env:
           target: buildpacks.${{ github.event.inputs.buildpack }}.tests
         run: |
           make $target
       - name: Publish Container
-        with:
+        env:
           url: ${{ env.DEPENDENCY_BASE_URL }}
           registry: ${{ env.REGISTRY }}/${{ env.CONTAINER_PATH }} buildpacks.${{ github.event.inputs.buildpack }}.images.publish
         run: |
           make base_url=$url registry.location=other REGISTRY=$registry
       - name: Prepare Commit
-        with:
+        env:
           target: buildpacks.${{ github.event.inputs.buildpack }}.commit.prep
         run: |
           make $target
       - name: Commit
-        with:
+        env:
           version: ./buildpacks/${{ github.event.inputs.buildpack }}/VERSION
           buildpack: ./buildpacks/${{ github.event.inputs.buildpack }}/buildpack.toml
           message: Update ${{ github.event.inputs.buildpack }} buildpack version to ${{ steps.version.outputs.version }}
@@ -87,14 +89,14 @@ jobs:
           git push
       - name: Create Tag
         id: tag
-        with:
+        env:
           tag: ${{ github.event.inputs.buildpack }}-buildpack/v${{ steps.version.outputs.version }}
         run: |
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"
       - id: artifacts
-        with:
+        env:
           online_image_file: ./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-${{ steps.version.outputs.version }}.image
           offline_image_file: ./out/buildpacks/${{ github.event.inputs.buildpack }}/${{ steps.version.outputs.version }}/${{ github.event.inputs.buildpack }}-buildpack-with-deps-${{ steps.version.outputs.version }}.image
         run: |

--- a/.github/workflows/create-buildpack-release.yaml
+++ b/.github/workflows/create-buildpack-release.yaml
@@ -58,7 +58,7 @@ jobs:
           version: ${{ steps.version.outputs.version }}
       - name: Bump Version
         run: |
-            printf  $version > $path
+          printf  $version > $path
       - name: Run Tests
         env:
           target: buildpacks.${{ github.event.inputs.buildpack }}.tests

--- a/.github/workflows/create-invoker-release.yaml
+++ b/.github/workflows/create-invoker-release.yaml
@@ -38,39 +38,42 @@ jobs:
           path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
+          version: ${{ steps.version.outputs.version }}
       - name: Bump version
         run: |
-          version="${{ steps.version.outputs.version }}"
-          version_output_path="./invokers/${{ github.event.inputs.invoker }}/VERSION"
-          printf $version > $version_output_path
+          printf $version > $path
       - name: Run Tests
+        with:
+          target: invokers.${{ github.event.inputs.invoker }}.tests
         run: |
-          target="invokers.${{ github.event.inputs.invoker }}.tests"
           make $target
       - name: Build
+        with:
+          target: invokers.${{ github.event.inputs.invoker }}.tests
         run: |
-          target="invokers.${{ github.event.inputs.invoker }}"
           make $target
       - name: Commit Version
+        with:
+          path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
+          message: Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}
         run: |
-          version_path="./invokers/${{ github.event.inputs.invoker }}/VERSION"
-          git add $version_path
+          git add $path
           git config user.name github-actions
           git config user.email github-actions@github.com
-          commit_message="Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}"
-          git commit -m '$commit_message'
+          git commit -m '$message'
           git push
       - name: Create Tag
         id: tag
+        with:
+          tag: ${{ github.event.inputs.invoker }}-invoker/v${{ steps.version.outputs.version }}
         run: |
-          tag="${{ github.event.inputs.invoker }}-invoker/v${{ steps.version.outputs.version }}"
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"
       - id: artifacts
+        with:
+          files: ./out/invokers/${{ github.event.inputs.invoker }}/*.sha256
         run: |
-          files=./out/invokers/${{ github.event.inputs.invoker }}/*.sha256
-
           echo 'invoker_files<<EOF' >> $GITHUB_ENV
           ls ${files} | rev | cut -d. -f 2- | rev >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV

--- a/.github/workflows/create-invoker-release.yaml
+++ b/.github/workflows/create-invoker-release.yaml
@@ -76,7 +76,6 @@ jobs:
         env:
           files_path: "./out/invokers/${{ github.event.inputs.invoker }}"
         run: |
-          ls $files_path
           files=$files_path/*.sha256
           echo 'invoker_files<<EOF' >> $GITHUB_ENV
           ls ${files} | rev | cut -d. -f 2- | rev >> $GITHUB_ENV

--- a/.github/workflows/create-invoker-release.yaml
+++ b/.github/workflows/create-invoker-release.yaml
@@ -38,22 +38,24 @@ jobs:
           path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
+        env:
+          path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
           version: ${{ steps.version.outputs.version }}
       - name: Bump version
         run: |
           printf $version > $path
       - name: Run Tests
-        with:
+        env:
           target: invokers.${{ github.event.inputs.invoker }}.tests
         run: |
           make $target
       - name: Build
-        with:
+        env:
           target: invokers.${{ github.event.inputs.invoker }}.tests
         run: |
           make $target
       - name: Commit Version
-        with:
+        env:
           path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
           message: Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}
         run: |
@@ -64,14 +66,14 @@ jobs:
           git push
       - name: Create Tag
         id: tag
-        with:
+        env:
           tag: ${{ github.event.inputs.invoker }}-invoker/v${{ steps.version.outputs.version }}
         run: |
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"
       - id: artifacts
-        with:
+        env:
           files: ./out/invokers/${{ github.event.inputs.invoker }}/*.sha256
         run: |
           echo 'invoker_files<<EOF' >> $GITHUB_ENV

--- a/.github/workflows/create-invoker-release.yaml
+++ b/.github/workflows/create-invoker-release.yaml
@@ -38,10 +38,10 @@ jobs:
           path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
           release-type: ${{ github.event.inputs.release-type }}
           pre-release: ${{ github.event.inputs.pre-release-label }}
+      - name: Bump version
         env:
           path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
           version: ${{ steps.version.outputs.version }}
-      - name: Bump version
         run: |
           printf $version > $path
       - name: Run Tests
@@ -51,18 +51,18 @@ jobs:
           make $target
       - name: Build
         env:
-          target: invokers.${{ github.event.inputs.invoker }}.tests
+          target: invokers.${{ github.event.inputs.invoker }}
         run: |
           make $target
       - name: Commit Version
         env:
           path: ./invokers/${{ github.event.inputs.invoker }}/VERSION
-          message: Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}
+          message: "Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}"
         run: |
           git add $path
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m '$message'
+          git commit -m "${message}"
           git push
       - name: Create Tag
         id: tag
@@ -74,8 +74,10 @@ jobs:
           echo "::set-output name=tag::$tag"
       - id: artifacts
         env:
-          files: ./out/invokers/${{ github.event.inputs.invoker }}/*.sha256
+          files_path: "./out/invokers/${{ github.event.inputs.invoker }}"
         run: |
+          ls $files_path
+          files=$files_path/*.sha256
           echo 'invoker_files<<EOF' >> $GITHUB_ENV
           ls ${files} | rev | cut -d. -f 2- | rev >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV

--- a/.github/workflows/create-invoker-release.yaml
+++ b/.github/workflows/create-invoker-release.yaml
@@ -40,24 +40,30 @@ jobs:
           pre-release: ${{ github.event.inputs.pre-release-label }}
       - name: Bump version
         run: |
-          printf "${{ steps.version.outputs.version }}" > ./invokers/${{ github.event.inputs.invoker }}/VERSION
+          version="${{ steps.version.outputs.version }}"
+          version_output_path="./invokers/${{ github.event.inputs.invoker }}/VERSION"
+          printf $version > $version_output_path
       - name: Run Tests
         run: |
-          make invokers.${{ github.event.inputs.invoker }}.tests
+          target="invokers.${{ github.event.inputs.invoker }}.tests"
+          make $target
       - name: Build
         run: |
-          make invokers.${{ github.event.inputs.invoker }}
+          target="invokers.${{ github.event.inputs.invoker }}"
+          make $target
       - name: Commit Version
         run: |
-          git add ./invokers/${{ github.event.inputs.invoker }}/VERSION
+          version_path="./invokers/${{ github.event.inputs.invoker }}/VERSION"
+          git add $version_path
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m 'Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}'
+          commit_message="Update ${{ github.event.inputs.invoker }} invoker version to ${{ steps.version.outputs.version }}"
+          git commit -m '$commit_message'
           git push
       - name: Create Tag
         id: tag
         run: |
-          tag=${{ github.event.inputs.invoker }}-invoker/v${{ steps.version.outputs.version }}
+          tag="${{ github.event.inputs.invoker }}-invoker/v${{ steps.version.outputs.version }}"
           git tag $tag
           git push --tags
           echo "::set-output name=tag::$tag"

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ templates/java/cloudevents-maven/target/
 templates/java/http-gradle/.gradle/
 templates/java/http-maven/target/
 tests/cases/echo-ce/java/target/
+
+# Github Actions
+node_modules/


### PR DESCRIPTION
## Which issue(s) this PR fixes

Some of our scripts in the GitHub actions are subject to [script injection attacks](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

We can
* [Use an action instead of an inline script](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-action-instead-of-an-inline-script-recommended)
* Using [intermediate environment variables](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) 

we can fix it by storing the evaluation in a variable before using it.
