### PR TITLE
Update README.md

### DIFF
--- a/buildpacks/python/README.md
+++ b/buildpacks/python/README.md
@@ -103,7 +103,7 @@ docker push <your_image_name_and_tag>
 
 ## Health Endpoints
 
-The Python Invoker has health endpoints exposed by `healthz`. By default, the path is found at `localhost:8080/healthz/live` or `localhost:8080/healthz/ready`.
+The Python Invoker has health endpoints exposed by `health`. By default, the path is found at `localhost:8080/health/live` or `localhost:8080/health/ready`.
 
 ## Templates
 If you want to quickly start writing your functions, take a look at the `templates/python` folder at the root of this repo.


### PR DESCRIPTION
Signed-off-by: Bryan Tong <tongb@vmware.com>

Resolves `healthz` -> `health` misnaming.