### PR TITLE
JVM 17 is required since Spring 3 is now used for Java Invoker

### DIFF
--- a/tests/testdata/template_and_smoke/echo-ce/Makefile
+++ b/tests/testdata/template_and_smoke/echo-ce/Makefile
@@ -13,7 +13,7 @@ echo-ce.image := kn-fn-test/echo-ce
 echo-ce.image_paths := $(filter-out %/Makefile, $(wildcard $(echo-ce.path)/*))
 
 $(echo-ce.image_paths): $(PACK) $(builder.image.out)
-	cd $@ && $(PACK) build $(echo-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=$(echo-ce.env.$(notdir $@)) --pull-policy if-not-present --clear-cache
+	cd $@ && $(PACK) build $(echo-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_JVM_VERSION=17 --env BP_FUNCTION=$(echo-ce.env.$(notdir $@)) --pull-policy if-not-present --clear-cache
 
 echo-ce.clean := $(addsuffix .clean,$(echo-ce.image_paths))
 $(echo-ce.clean):

--- a/tests/testdata/template_and_smoke/helloworld/Makefile
+++ b/tests/testdata/template_and_smoke/helloworld/Makefile
@@ -13,7 +13,7 @@ helloworld.image := kn-fn-test/helloworld
 helloworld.image_paths := $(filter-out %/Makefile, $(wildcard $(helloworld.path)/*))
 
 $(helloworld.image_paths): $(PACK) $(builder.image.out)
-	cd $@ && $(PACK) build $(helloworld.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=$(helloworld.env.$(notdir $@)) --pull-policy if-not-present --clear-cache
+	cd $@ && $(PACK) build $(helloworld.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_JVM_VERSION=17 --env BP_FUNCTION=$(helloworld.env.$(notdir $@)) --pull-policy if-not-present --clear-cache
 
 helloworld.clean := $(addsuffix .clean,$(helloworld.image_paths))
 $(helloworld.clean):

--- a/tests/testdata/template_and_smoke/template-ce/Makefile
+++ b/tests/testdata/template_and_smoke/template-ce/Makefile
@@ -20,7 +20,7 @@ $(template-ce.path)/%: $$(foreach v,%, $$(addprefix $(ROOT_DIR)/templates/,$$(fi
 	ln -sf $< $@
 
 $(template-ce.out): $(out_dir)/tests/template/%: $(template-ce.path)/% $(PACK) $(builder.image.out)
-	cd $< && $(PACK) build $(template-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=$(template-ce.$(firstword $(subst -, ,$*)).bp_function) --pull-policy if-not-present --clear-cache
+	cd $< && $(PACK) build $(template-ce.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_JVM_VERSION=17 --env BP_FUNCTION=$(template-ce.$(firstword $(subst -, ,$*)).bp_function) --pull-policy if-not-present --clear-cache
 
 template-ce.image := kn-fn-test/template-ce
 template-ce.clean := $(addsuffix .clean,$(template-ce.out))

--- a/tests/testdata/template_and_smoke/template-http/Makefile
+++ b/tests/testdata/template_and_smoke/template-http/Makefile
@@ -20,7 +20,7 @@ $(template-http.path)/%: $$(foreach v,%, $$(addprefix $(ROOT_DIR)/templates/,$$(
 	ln -sf $< $@
 
 $(template-http.out): $(out_dir)/tests/template/%: $(template-http.path)/% $(PACK) $(builder.image.out)
-	cd $< && $(PACK) build $(template-http.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_FUNCTION=$(template-http.$(firstword $(subst -, ,$*)).bp_function) --pull-policy if-not-present --clear-cache
+	cd $< && $(PACK) build $(template-http.image):$(notdir $@) --builder $(shell cat $(builder.image.out)) --env BP_JVM_VERSION=17 --env BP_FUNCTION=$(template-http.$(firstword $(subst -, ,$*)).bp_function) --pull-policy if-not-present --clear-cache
 
 template-http.image := kn-fn-test/template-http
 template-http.clean := $(addsuffix .clean,$(template-http.out))


### PR DESCRIPTION
Java 17 is required since Spring 3 is now used for Java Invoker.  Environment variable BP_JVM_VERSION is required until buildpacks default to Java 17 instead of 11. 