### PR TITLE
chore(srp) Enable SRP to run again

### DIFF
--- a/.github/actions/srp-helper/install/action.yml
+++ b/.github/actions/srp-helper/install/action.yml
@@ -9,5 +9,5 @@ runs:
     - id: install
       run: ${{ github.action_path }}/install.sh
       env:
-        SRP_CLIENT_URL: ${{secrets.SRP_CLIENT_URL}}
+        SRP_CLIENT_URL: ${{ inputs.client-url }}
       shell: bash

--- a/.github/workflows/vmware-srp-report.yaml
+++ b/.github/workflows/vmware-srp-report.yaml
@@ -25,6 +25,8 @@ jobs:
         client-secret: ${{ secrets.SRP_CLIENT_SECRET }}
     - name: Install SRP
       uses: ./.github/actions/srp-helper/install
+      with:
+        client-url: ${{ secrets.SRP_CLIENT_URL }}
     - name: Initialize SRP
       uses: ./.github/actions/srp-helper/init
       with:


### PR DESCRIPTION
SRP is not running since moving the urls to secrets. Fix it by passing secrets from the top workflow to the called workflow using the "with:" syntax.