### PR TITLE
Require setuptools>=40.8.0

### DIFF
--- a/invokers/python/Dockerfile
+++ b/invokers/python/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /workspace/invoker
 RUN tox sdist
 RUN mkdir -p /out
 RUN cp /workspace/invoker/.tox/dist/*.tar.gz /out
-RUN pip download --no-binary 'MarkupSafe' -d /workspace/dependencies .
+RUN pip download --no-binary 'MarkupSafe' 'setuptools>=40.8.0' -d /workspace/dependencies .
 RUN tar -cvzf /out/pyfunc-invoker-deps-$(cat /workspace/invoker/VERSION).tar.gz -C /workspace/dependencies .
 
 ENTRYPOINT [ "tox" ]


### PR DESCRIPTION
This PR may resolve an issue with tanzu-python's failing Action's integration test.

Signed-off-by: Bryan Tong <tongb@vmware.com>